### PR TITLE
fix: render config checksum annotation regardless of podAnnotations

### DIFF
--- a/charts/borg-server/templates/deployment.yaml
+++ b/charts/borg-server/templates/deployment.yaml
@@ -13,11 +13,11 @@ spec:
       {{- include "borg-server.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
         checksum/config: {{ printf "%s%s" (include (print $.Template.BasePath "/configmap.yaml") .) (include (print $.Template.BasePath "/secret.yaml") .) | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "borg-server.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
The `checksum/config` annotation was nested inside the `{{- with .Values.podAnnotations }}` block in the deployment template. Since `podAnnotations` defaults to `{}`, the checksum was never rendered unless the user explicitly set a pod annotation. As a result, changes to ConfigMaps or Secrets (sshd config, sssd config, host keys) would not trigger automatic pod restarts.

This moves the checksum annotation outside the `with` block so it is always rendered, while keeping user-defined podAnnotations conditional.