### PR TITLE
fix: migrate HPA template from autoscaling/v2beta1 to v2

### DIFF
--- a/charts/borg-server/templates/hpa.yaml
+++ b/charts/borg-server/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "borg-server.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
The HPA template uses `autoscaling/v2beta1` which was removed in Kubernetes 1.26. This migrates it to `autoscaling/v2` and updates the metric target structure from `targetAverageUtilization` to the `target.type`/`target.averageUtilization` format required by the stable API.