### PR TITLE
chore: migrate Renovate config to current format

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,55 +1,9 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:recommended"
-    ],
-    "baseBranches": [
-        "main"
-    ],
-    "rebaseWhen": "conflicted",
-    "labels": [
-        "dependencies"
-    ],
     "repositories": [
         "borg-fleet/helm-charts"
     ],
-    "automerge": true,
-    "automergeType": "pr",
-    "platformAutomerge": true,
-    "recreateWhen": "always",
-    "automergeStrategy": "merge-commit",
-    "prHourlyLimit": 10,
-    "bumpVersion": "patch",
-    "customManagers": [
-        {
-            "customType": "regex",
-            "managerFilePatterns": [
-                "/(^|/)Chart\\.yaml$/"
-            ],
-            "matchStrings": [
-                "#\\s?renovate: image=(?<depName>.*?)\\s?appVersion:\\s?\\\"?(?<currentValue>[\\w+\\.\\-]*)"
-            ],
-            "datasourceTemplate": "docker"
-        }
-    ],
-    "packageRules": [
-        {
-            "matchDatasources": [
-                "docker"
-            ],
-            "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$"
-        }
-    ],
     "allowedCommands": [
         "./bump_chart_version.sh"
-    ],
-    "postUpgradeTasks": {
-        "commands": [
-            "./bump_chart_version.sh"
-        ],
-        "fileFilters": [
-            "**/*"
-        ],
-        "executionMode": "branch"
-    }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended"
+    ],
+    "baseBranchPatterns": [
+        "main"
+    ],
+    "rebaseWhen": "conflicted",
+    "labels": [
+        "dependencies"
+    ],
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": true,
+    "recreateWhen": "always",
+    "automergeStrategy": "merge-commit",
+    "prHourlyLimit": 10,
+    "bumpVersion": "patch",
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)Chart\\.yaml$/"
+            ],
+            "matchStrings": [
+                "#\\s?renovate: image=(?<depName>.*?)\\s?appVersion:\\s?\\\"?(?<currentValue>[\\w+\\.\\-]*)"
+            ],
+            "datasourceTemplate": "docker"
+        }
+    ],
+    "packageRules": [
+        {
+            "matchDatasources": [
+                "docker"
+            ],
+            "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$"
+        }
+    ],
+    "postUpgradeTasks": {
+        "commands": [
+            "./bump_chart_version.sh"
+        ],
+        "fileFilters": [
+            "**/*"
+        ],
+        "executionMode": "branch"
+    }
+}


### PR DESCRIPTION
The Dependency Dashboard (issue #4) reports "Config Migration Needed" and "Found renovate config warnings" because `.github/renovate.json` serves as both the self-hosted config (via the GitHub Action `configurationFile` parameter) and is auto-discovered as the repo config. This causes warnings for global-only options `repositories` and `allowedCommands` appearing in the repo config.

This PR splits the configuration:

- `.github/renovate.json` now contains only global/self-hosted options (`repositories`, `allowedCommands`) and continues to be referenced by the GitHub Action workflow
- `renovate.json` (repo root) contains the repo-level config, which Renovate auto-discovers with higher priority than `.github/renovate.json`
- Migrates deprecated `baseBranches` to `baseBranchPatterns`