### PR TITLE
Remove deprecated Kubernetes API fallbacks from ingress template

### DIFF
--- a/charts/borg-server/Chart.yaml
+++ b/charts/borg-server/Chart.yaml
@@ -11,6 +11,7 @@ maintainers:
   - name: phihos
     email: philipp.hossner@posteo.de
     url: https://github.com/phihos
+kubeVersion: ">=1.22.0"
 type: application
 version: 0.1.24
 # renovate: image=ghcr.io/borg-fleet/borg

--- a/charts/borg-server/templates/ingress.yaml
+++ b/charts/borg-server/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "borg-server.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -43,19 +32,14 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            {{- if .pathType }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
The ingress template contained fallback paths for networking.k8s.io/v1beta1 (K8s <1.19) and extensions/v1beta1 (K8s <1.14). Both APIs were removed in K8s 1.22, making these branches dead code. This simplifies the template to only use the stable networking.k8s.io/v1 API and adds kubeVersion: ">=1.22.0" to Chart.yaml to document the minimum supported Kubernetes version.