### PR TITLE
Disable SSH password authentication by default

### DIFF
--- a/charts/borg-server/values.yaml
+++ b/charts/borg-server/values.yaml
@@ -141,7 +141,7 @@ config:
     Port: 22
     UsePam: 'yes'
     PermitRootLogin: 'no'
-    PasswordAuthentication: 'yes'
+    PasswordAuthentication: 'no'
     ChallengeResponseAuthentication: 'no'
     KerberosAuthentication: 'no'
     GSSAPIAuthentication: 'no'

--- a/test/borg-server-values.yaml
+++ b/test/borg-server-values.yaml
@@ -114,6 +114,8 @@ config:
       ldap_user_ssh_public_key: sshPublicKey
       ldap_default_bind_dn: cn=admin,dc=example,dc=org
       ldap_default_authtok: admin
+  sshd:
+    PasswordAuthentication: 'yes'
 
 persistence:
   # normally should be ReadWriteMany but kind only supports ReadWriteOnce by default


### PR DESCRIPTION
The default sshd configuration shipped with PasswordAuthentication set to yes. For a borg backup server, key-based authentication is the expected access method and password auth is an unnecessary attack surface. This changes the default to no. Users who need password auth can override it in their values.